### PR TITLE
Make create-chat actually put a chat in the db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.962.0",
         "@aws-sdk/lib-dynamodb": "^3.962.0",
-        "esbuild": "^0.27.2"
+        "esbuild": "^0.27.2",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.159",
@@ -6441,6 +6442,18 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.962.0",
     "@aws-sdk/lib-dynamodb": "^3.962.0",
-    "esbuild": "^0.27.2"
+    "esbuild": "^0.27.2",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.159",

--- a/src/lambdas/create-chat/lambda.ts
+++ b/src/lambdas/create-chat/lambda.ts
@@ -1,17 +1,42 @@
 import {APIGatewayProxyEvent} from "aws-lambda"
-import {HTTPResponse} from "../../shared/models"
+import {CreateChatResponse, HTTPResponse} from "../../shared/models"
+import {DynamoDBClient} from "@aws-sdk/client-dynamodb"
+import {DynamoDBDocumentClient, PutCommand, PutCommandOutput} from "@aws-sdk/lib-dynamodb"
+import {v4 as UUID4} from "uuid"
 const logger = console.log
+const CHAT_TABLE_NAME: string = process.env.CHAT_TABLE_NAME
+const dynamoDBClient: DynamoDBDocumentClient = DynamoDBDocumentClient.from(new DynamoDBClient())
 
-export async function handler (event: APIGatewayProxyEvent): Promise<HTTPResponse> {
+
+const handler = async (event: APIGatewayProxyEvent): Promise<HTTPResponse> => {
     logger("Attempt made to create a new chat")
 
-    const content: string = JSON.stringify({ chatId: "007", timestamp: 1234567890 })
+    const body: any = JSON.parse(event.body)
+    const newChatId: string = UUID4()
+
+    const dynamoDBDocumentClient: DynamoDBDocumentClient = DynamoDBDocumentClient.from(dynamoDBClient)
+    const cmd: PutCommand = new PutCommand({
+        TableName: CHAT_TABLE_NAME,
+        Item: {
+            chatId: newChatId,
+            userId: body.userId || '007',
+            name: body.name || 'Batman',
+            timestamp: Date.now()
+        },
+        ReturnValues: "ALL_OLD"
+    })
+
+    let newItem: PutCommandOutput = await dynamoDBDocumentClient.send(cmd)
+    const response: CreateChatResponse = newItem.Attributes as any
+    const content: string = JSON.stringify(response)
     return {
         body: content,
         statusCode: 201,
         headers: {
             "content-type": "application/json",
-            "x-chat-id": 0.007
+            "x-chat-id": newChatId
         }
     }
 }
+
+export { handler }

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -1,5 +1,15 @@
 export interface HTTPResponse {
     statusCode: number
-    body: string,
+    body: string
     headers?: Record<string, any>
+}
+
+export interface CreateChatRequest {
+    chatId: string
+    userId: string
+    name: string
+}
+
+export interface CreateChatResponse {
+
 }

--- a/terraform/chat-api-swagger.yaml
+++ b/terraform/chat-api-swagger.yaml
@@ -5,7 +5,7 @@ info:
   description: Simple chat API
 
 paths:
-  /chat:
+  /v1/chat:
     post:
       summary: Create a new chat
       operationId: createChat

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,1 +1,21 @@
+resource "aws_dynamodb_table" "chat_table" {
+  name = "chats"
+  billing_mode = "PAY_PER_REQUEST"
 
+  hash_key       = "chatId"
+  range_key      = "userId"
+
+  attribute {
+    name = "chatId"
+    type = "S"
+  }
+
+  attribute {
+    name = "userId"
+    type = "S"
+  }
+
+  tags = {
+    Environment = "dev"
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,46 @@
+resource "aws_iam_role" "create_chat_role" {
+  name               = "create_chat_role_execution_role"
+  assume_role_policy = data.aws_iam_policy_document.assume_chat_role.json
+}
+
+data "aws_iam_policy_document" "assume_chat_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "chat_lambda_permissions" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:DescribeTable"
+    ]
+    resources = [
+      aws_dynamodb_table.chat_table.arn
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "chat_lambda_inline_policy" {
+  name   = "chat-lambda-dynamodb-logs"
+  role   = aws_iam_role.create_chat_role.id
+  policy = data.aws_iam_policy_document.chat_lambda_permissions.json
+}
+

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "create_chat_lambda" {
 
   environment {
     variables = {
+      CHAT_TABLE_NAME = aws_dynamodb_table.chat_table.name
       ENVIRONMENT = "dev"
       LOG_LEVEL   = "info"
     }
@@ -18,24 +19,6 @@ resource "aws_lambda_function" "create_chat_lambda" {
     Environment = "dev"
     App         = "web-chat-app"
   }
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-resource "aws_iam_role" "create_chat_role" {
-  name               = "create_chat_role_execution_role"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_lambda_permission" "allow_api_gateway_invoke" {


### PR DESCRIPTION
Added a dynamo db table and wired up the correct policies and roles. The lambda does a putItem into the table using either the values pass in the request or defaulting to some nonesense text.